### PR TITLE
Reactnative/update

### DIFF
--- a/src/jekyll/_data/sdkPlatforms.yml
+++ b/src/jekyll/_data/sdkPlatforms.yml
@@ -8,7 +8,7 @@ tapsellAndroid:
 
 tapsellUnity:
   sdkVersion: 4.6.2
-  releaseNotesFileFa: releases/tapsell-unity.md 
+  releaseNotesFileFa: releases/tapsell-unity.md
 
 tapsellReact:
   sdkVersion: 4.6.2
@@ -42,7 +42,7 @@ plusUnity:
   issues: https://github.com/tapsellorg/TapsellPlusSDK-UnitySample2020/issues?q=is%3Aissue
 
 plusReactnative:
-  sdkVersion: 2.1.3
+  sdkVersion: 2.1.6
   sample: https://github.com/tapsellorg/TapsellPlusSDK-ReactNativeSample
   releaseNotesFileFa: releases/plus-reactnative.md
   github: https://github.com/tapsellorg/TapsellPlusSDK-ReactNativePlugin

--- a/src/jekyll/_includes/releases/plus-reactnative.md
+++ b/src/jekyll/_includes/releases/plus-reactnative.md
@@ -7,6 +7,9 @@
 - رفع مشکل کرش در نسخه iOS
 - بروزرسانی نسخه react native به ۰.۶۷.۱ در اپلیکیشن سمپل
 - افزودن پشتیبانی از hermes engine در اپلیکیشن سمپل
+#### Android
+- [بروزرسانی لایبرری اندروید تپسل پلاس به نسخه‌ی ۲.۱.۶](https://docs.tapsell.ir/plus-sdk/android/main/#v216---20220111)
+- [بروزرسانی لایبرری اندروید تپسل به نسخه‌ی ۴.۷.۴](https://docs.tapsell.ir/tapsell-sdk/android/main/#474---20220110)
 
 ## 2.1.3 (24, July, 2021)
 - [استفاده از نسخه‌ی ۲.۱.۳ تپسل پلاس](https://docs.tapsell.ir/plus-sdk/android/main/#v213---20210721)

--- a/src/jekyll/_includes/releases/plus-reactnative.md
+++ b/src/jekyll/_includes/releases/plus-reactnative.md
@@ -7,6 +7,7 @@
 - رفع مشکل کرش در نسخه iOS
 - بروزرسانی نسخه react native به ۰.۶۷.۱ در اپلیکیشن سمپل
 - افزودن پشتیبانی از hermes engine در اپلیکیشن سمپل
+
 #### Android
 - [بروزرسانی لایبرری اندروید تپسل پلاس به نسخه‌ی ۲.۱.۶](https://docs.tapsell.ir/plus-sdk/android/main/#v216---20220111)
 - [بروزرسانی لایبرری اندروید تپسل به نسخه‌ی ۴.۷.۴](https://docs.tapsell.ir/tapsell-sdk/android/main/#474---20220110)

--- a/src/jekyll/_includes/releases/plus-reactnative.md
+++ b/src/jekyll/_includes/releases/plus-reactnative.md
@@ -2,6 +2,12 @@
 
 ([جزئیات بیشتر تاریخچه](https://github.com/tapsellorg/TapsellPlusSDK-ReactNativePlugin/blob/master/CHANGELOG.md))
 
+## 2.1.6 (05, Feb, 2022)
+- رفع مشکل گزارش شده در metro bundler پس از نصب SDK روی react native نسخه های ۰.۶۴.۰ به بالا
+- رفع مشکل کرش در نسخه iOS
+- بروزرسانی نسخه react native به ۰.۶۷.۱ در اپلیکیشن سمپل
+- افزودن پشتیبانی از hermes engine در اپلیکیشن سمپل
+
 ## 2.1.3 (24, July, 2021)
 - [استفاده از نسخه‌ی ۲.۱.۳ تپسل پلاس](https://docs.tapsell.ir/plus-sdk/android/main/#v213---20210721)
 - [استفاده از نسخه‌ی ۴.۷.۲ تپسل](https://docs.tapsell.ir/tapsell-sdk/android/main/#472---20210720)

--- a/src/jekyll/docs/plus-sdk/reactnative/add-adnetworks-fa.md
+++ b/src/jekyll/docs/plus-sdk/reactnative/add-adnetworks-fa.md
@@ -58,13 +58,13 @@ toc: true
 
 ```gradle
 dependencies {
-    .......
+    //.......
     //for adMob
-    implementation 'com.google.android.gms:play-services-ads:20.2.0'
-
+    // For 20.0.0 and later <meta-data> tag is needed
+    // For lower versions meta-data tag is not needed
+    implementation 'com.google.android.gms:play-services-ads:20.4.0'
     //for unityAds
-    implementation 'com.unity3d.ads:unity-ads:3.7.4'
-
+    implementation 'com.unity3d.ads:unity-ads:3.7.5'
     //for chartboost
     implementation 'com.chartboost:chartboost-sdk:8.2.1'
     implementation ("com.google.android.gms:play-services-base:17.6.0"){
@@ -75,14 +75,22 @@ dependencies {
     }
     
     //for adcolony
-    implementation 'com.adcolony:sdk:4.5.0'
+    implementation 'com.adcolony:sdk:4.6.5'
     implementation ("com.google.android.gms:play-services-ads-identifier:17.0.0"){
         exclude group: 'com.android.support'
     }
     
     //for applovin
-    implementation 'com.applovin:applovin-sdk:10.3.1'
-    .....
+    implementation 'com.applovin:applovin-sdk:10.3.4'
+    // For Mintegral - NOTE: Add custom repository (explained after this)
+    implementation "com.mbridge.msdk.oversea:videojs:15.6.11"
+    implementation "com.mbridge.msdk.oversea:mbbanner:15.6.11"
+    implementation "com.mbridge.msdk.oversea:mbjscommon:15.6.11"
+    implementation "com.mbridge.msdk.oversea:playercommon:15.6.11"
+    implementation "com.mbridge.msdk.oversea:reward:15.6.11"
+    implementation "com.mbridge.msdk.oversea:videocommon:15.6.11"
+    implementation "com.mbridge.msdk.oversea:same:15.6.11"
+    implementation "com.mbridge.msdk.oversea:interstitialvideo:15.6.11"
 }
 ```
 

--- a/src/jekyll/docs/plus-sdk/reactnative/add-adnetworks-fa.md
+++ b/src/jekyll/docs/plus-sdk/reactnative/add-adnetworks-fa.md
@@ -82,6 +82,7 @@ dependencies {
     
     //for applovin
     implementation 'com.applovin:applovin-sdk:10.3.4'
+    
     // For Mintegral - NOTE: Add custom repository (explained after this)
     implementation "com.mbridge.msdk.oversea:videojs:15.6.11"
     implementation "com.mbridge.msdk.oversea:mbbanner:15.6.11"
@@ -94,29 +95,31 @@ dependencies {
 }
 ```
 
-برای adcolony و chartboost لازم است ریپازیتوری‌های زیر به android/build.gradle پروژه اضافه شوند.
-
-
+همچنین بسته به ادنتورک اضافه شده بایستی repository مورد استفاده برای دانلود آنهایی که از mavenCentral استفاده نمی‌کنند، نیز اضافه شود:
 
 ```gradle
 allprojects {  
     repositories {
-        ....
+        //....
 
+        // TapsellPlus, Tapsell, ...
         mavenCentral()
+        
+        // Old libraries
         jcenter()
 
-        // for v1.2.3-rc4 and before
-        //maven {  
-        //    url  "https://adcolony.bintray.com/AdColony"
-        //}
-        //maven {
-        //    url "https://chartboostmobile.bintray.com/Chartboost"
-        //}
-        ....
+        // Mintegral - This will lead to 403 even with Shecan and FOD. Needs a strong VPN protocol
+        maven {
+            url  "https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea"
+        }
     }  
 }
 ```
+
+
+> برای اضافه‌کردن **مینتگرال** نیاز به VPN یا پراکسی با پروتکل مناسب مانند Kerio یا OpenVPN دارید. در حال حاضر این سرورها توسط شکن یا FOD پشتیبانی نمی‌شوند
+{:data-title="نکته برای استفاده از مینتگرال" data-color="red"}
+
 
 برای استفاده از شبکه‌ی تبلیغاتی Unity Ads می‌بایست minSDK اپلیکیشن خود را ۱۹ قرار دهید. و یا این که خط زیر را به فایل AndroidManifest.xml پروژه‌تان اضافه نمایید.
 

--- a/src/jekyll/docs/plus-sdk/reactnative/adnetworks-test-fa.md
+++ b/src/jekyll/docs/plus-sdk/reactnative/adnetworks-test-fa.md
@@ -61,3 +61,6 @@ TapsellPlus.initialize("alsoatsrtrotpqacegkehkaiieckldhrgsbspqtgqnbrrfccrtbdomgj
 |    AppLovin    |     Rewarded Video     |`5d3eb48c3aef7a0001406f84`|
 |    AppLovin    |     Interstitial     |`5d3eb4fa3aef7a0001406f85`|
 |    AppLovin    |     Standard     |`5d3eb5337a9b060001892441`|
+|    Mintegral    |     Rewarded Video     |`612232e33cf0307ab73e9a3f`|
+|    Mintegral    |     Interstitial     |`612b6f24e2645f79d3f3549e`|
+|    Mintegral    |     Standard     |`615800246cd7ee3cd28f15d6`|


### PR DESCRIPTION
Update Version to 2.1.6 (05 Feb, 2022)
- [**New**]: Add Vast Activity to Github Sample
- [**New**]: Add AppSetId due to new changes to advertisingId
- [**New**]: Add support for Mintegral Interstitial and Rewarded Ads
- [**New**]: Add support for Mintegral standard banner ads
- [**New**] Enable Hermes Engine support in sample
- [*Fix*] Fixed a critical issue in metro bundler after installing sdk on react native +0.64
- [*Fix*] Fixed crash when running ios version
- [*Fix*] Fixed Admob native banner crash
- [*Fix*] Fixed consistent request in VAST
- [*Fix*] Fixed back button activation and show exit dialog option in Tapsell rewarded videos
- [*Fix*] Fixed Tapsell Native Banner NullPointerException
- [*Fix*] Fixed Standard banner refresh issue: it will now remove the previous banner if the request was failed and banner was not in shown state
  - Modified adNetworks: AppLovin, AdMob, Tapsell, Mintegral
- [change] Update Android dependency (TapsellPlus) to 2.1.6
- [change] Update sample react-native version to 0.67.1
- [change] Error will notify more verbosely when all adNetworks failed to load
- [change] Update Tapsell version to 4.7.4