### PR TITLE
chore: update react native plugin to 2.2.0

### DIFF
--- a/src/jekyll/_data/sdkPlatforms.yml
+++ b/src/jekyll/_data/sdkPlatforms.yml
@@ -46,7 +46,7 @@ plusUnity:
   faq: /faq/plus-sdk/unity/
 
 plusReactnative:
-  sdkVersion: 2.1.8
+  sdkVersion: 2.2.0
   sample: https://github.com/tapsellorg/TapsellPlusSDK-ReactNativeSample
   releaseNotesFileFa: releases/plus-reactnative.md
   github: https://github.com/tapsellorg/TapsellPlusSDK-ReactNativePlugin

--- a/src/jekyll/_includes/releases/plus-reactnative.md
+++ b/src/jekyll/_includes/releases/plus-reactnative.md
@@ -2,6 +2,23 @@
 
 ([جزئیات بیشتر تاریخچه](https://github.com/tapsellorg/TapsellPlusSDK-ReactNativePlugin/blob/master/CHANGELOG.md))
 
+## 2.2.0 - 2023/06/01
+- رفع مشکل Google Play Policy Error مربوط به جمع‌آوری اطلاعات اپ‌های نصب شده کاربر. باگ [68](https://github.com/tapsellorg/TapsellPlusSDK-AndroidSample/issues/68)
+- اضافه شدن `UI` جدید برای دیالوگ بازگشت در تبلیغات ویدیویی
+
+  <img width="350" src="https://github.com/tapsellorg/TapsellDocument/assets/38072572/da643aec-1cc5-4699-81f6-1bde4226f6bc"  alt='New Dialog UI'/>
+- به‌روز‌رسانی کتابخانه اندروید تپسل به نسخه `2.2.0`
+- به‌روز‌رسانی نسخه‌ی ریکت‌نیتیو سمپل به `0.71.11`
+- رفع تعدادی از `Memory Leak` های گزارش شده
+- رفع تعدادی از مشکلات مربوط به `Proguard`
+- به‌روز‌رسانی `minSdkVersion` به نسخه 19 جهت پشتیبانی از ادموب نسخه `21.5.0`
+- رفع مشکل عملکرد اشتباه کلید های دیالوگ بازگشت در تبلیغات ویدیویی
+- به‌رو‌ز‌رسانی `Admob` به نسخه `21.5.0`
+- به‌رو‌ز‌رسانی `UnityAds` به نسخه `4.6.1`
+- به‌رو‌ز‌رسانی `Mintegral` به نسخه `16.3.91`
+- به‌رو‌ز‌رسانی `AdColony` به نسخه `4.8.0`
+- به‌رو‌ز‌رسانی `AppLovin` به نسخه `11.8.2`
+
 ## 2.1.8 - 2023/04/08
 - پشتیبانی از react native نسخه ۰.۷۱.۶
 - رفع مشکل کرش کردن metro bundler پس از افزودن پکیج

--- a/src/jekyll/docs/plus-sdk/reactnative/add-adnetworks-fa.md
+++ b/src/jekyll/docs/plus-sdk/reactnative/add-adnetworks-fa.md
@@ -52,7 +52,7 @@ toc: true
 > ۲. برای استفاده از ادنتورک **Google AdMob SDK** لازم است وابستگی `play-services-ads` را به صورت زیر در `android/app/build.gradle` قرار دهید.
 > ```groovy
 > dependencies {
->    def supportedAdmob = "20.6.0"
+>    def supportedAdmob = "21.5.0"
 >    implementation("com.google.android.gms:play-services-ads:$supportedAdmob")
 > }
 > ```
@@ -71,9 +71,9 @@ dependencies {
     //for adMob
     // For 20.0.0 and later <meta-data> tag is needed
     // For lower versions meta-data tag is not needed
-    implementation 'com.google.android.gms:play-services-ads:20.6.0'
+    implementation 'com.google.android.gms:play-services-ads:21.5.0'
     //for unityAds
-    implementation 'com.unity3d.ads:unity-ads:4.3.0'
+    implementation 'com.unity3d.ads:unity-ads:4.6.1'
     //for chartboost
     implementation 'com.chartboost:chartboost-sdk:8.2.1'
     implementation ("com.google.android.gms:play-services-base:17.6.0"){
@@ -84,23 +84,23 @@ dependencies {
     }
     
     //for adcolony
-    implementation 'com.adcolony:sdk:4.6.5'
+    implementation 'com.adcolony:sdk:4.8.0'
     implementation ("com.google.android.gms:play-services-ads-identifier:17.0.0"){
         exclude group: 'com.android.support'
     }
     
     //for applovin
-    implementation 'com.applovin:applovin-sdk:10.3.4'
+    implementation 'com.applovin:applovin-sdk:11.8.2'
     
     // For Mintegral - NOTE: Add custom repository (explained after this)
-    implementation "com.mbridge.msdk.oversea:videojs:15.6.11"
-    implementation "com.mbridge.msdk.oversea:mbbanner:15.6.11"
-    implementation "com.mbridge.msdk.oversea:mbjscommon:15.6.11"
-    implementation "com.mbridge.msdk.oversea:playercommon:15.6.11"
-    implementation "com.mbridge.msdk.oversea:reward:15.6.11"
-    implementation "com.mbridge.msdk.oversea:videocommon:15.6.11"
-    implementation "com.mbridge.msdk.oversea:same:15.6.11"
-    implementation "com.mbridge.msdk.oversea:interstitialvideo:15.6.11"
+    implementation "com.mbridge.msdk.oversea:videojs:16.3.91"
+    implementation "com.mbridge.msdk.oversea:mbbanner:16.3.91"
+    implementation "com.mbridge.msdk.oversea:mbjscommon:16.3.91"
+    implementation "com.mbridge.msdk.oversea:playercommon:16.3.91"
+    implementation "com.mbridge.msdk.oversea:reward:16.3.91"
+    implementation "com.mbridge.msdk.oversea:videocommon:16.3.91"
+    implementation "com.mbridge.msdk.oversea:same:16.3.91"
+    implementation "com.mbridge.msdk.oversea:interstitialvideo:16.3.91"
 }
 ```
 
@@ -142,6 +142,7 @@ allprojects {
 
 |  **نسخه‌ی تپسل‌پلاس** | **نسخه‌ی ادموب** | **تاریخ اتمام پشتیبانی** | **تاریخ اتمام دریافت تبلیغ** |
 |:-------------------:|:---------------:|:------------------------:|:----------------------------:|
+|        2.2.0        |      21.5.0     |          Q1 2024         |            Q2 2025           |
 |    2.1.7, 2,1,8     |      20.6.0     |          Q1 2023         |            Q2 2024           |
 | 2.1.4, 2.1.5, 2.1.6 |      20.4.0     |          Q1 2023         |            Q2 2024           |
 |        2.1.3        |      20.2.0     |          Q1 2023         |            Q2 2024           |


### PR DESCRIPTION
- [Fix]: Fixed Google Play policy error related to Collecting user's installed apps https://github.com/tapsellorg/TapsellPlusSDK-AndroidSample/issues/68
- [**Change**]: Increase `minSdkVersion` to 19 to support Admob `V21.5.0`
- [**New**]: Added new UI for back dialog
- [Change] Update Android dependency (TapsellPlus) to [`2.2.0`](https://docs.tapsell.ir/plus-sdk/android/main/#20220621-220)
- [Fix]: Fix some memory leaks in tapsell sdk and tapsell plus sdk
- [Fix]: fix some proguard issues
- [Fix]: Fix wrong back dialog options in rewarded videos
- [change] Update sample react-native version to 0.71.11
- [Change]: Update Admob to `V21.5.0`
- [Change]: Update UnityAds to `V4.6.1`
- [Change]: Update Mintegral to `V16.3.91`
- [Change]: Update AdColony to `V4.8.0`
- [Change]: Update AppLovin to `V11.8.2`